### PR TITLE
[bugfix] Fix race condition in logger.Global

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ 1.13, 1.14, 1.15, 1.16, 1.17 ]
+        go: [ 1.17 ]
     steps:
       - uses: actions/checkout@v2
 

--- a/logger/global.go
+++ b/logger/global.go
@@ -35,7 +35,7 @@ func (g *Global) SetAdapter(adapter Adapter) {
 func (g *Global) getLogger() LocalLogger {
 	logger, ok := g.logger.Load().(LocalLogger)
 	if !ok {
-		g.logger.Store(LocalLogger{adapter: &initialGlobalNoopAdapter{}})
+		g.logger.CompareAndSwap(nil, LocalLogger{adapter: &initialGlobalNoopAdapter{}})
 
 		return g.getLogger()
 	}


### PR DESCRIPTION
There is a chance that using two goroutines simultaneously, on an uninitialized global logger may lead to a bad outcome. One goroutine may want to log something, other want to set the adapter. The first one will realise that no adapter is set, the second one will set the adapter and then the first one will set the noop adapter. So eventually setting the adapter to specific implementation will not work.