### PR TITLE
Convert logger.Local from function to struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ lint:
 test:
 	go test -race -v ./...
 
+SRC := $(shell find -name main.go)
+
 .PHONY: build
-build:
-	go build ./...
+build: $(SRC)
+	for main in $(SRC) ; do \
+		go build $$main ; \
+	done

--- a/adapter/glogadapter/_example/main.go
+++ b/adapter/glogadapter/_example/main.go
@@ -17,10 +17,10 @@ func main() {
 
 	flag.Parse() // glog will pick command line options like -stderrthreshold=[INFO|WARNING|ERROR]
 	// create local logger
-	yalaLogger := logger.Local(glogadapter.Adapter{})
+	log := logger.Local{Adapter: glogadapter.Adapter{}}
 
-	yalaLogger.Debug(ctx, "Hello glog ") // Debug will be logged as Info
-	yalaLogger.With(ctx, "field_name", "field_value").Info("Some info")
-	yalaLogger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	yalaLogger.WithError(ctx, ErrSome).Error("Error occurred")
+	log.Debug(ctx, "Hello glog ") // Debug will be logged as Info
+	log.With(ctx, "field_name", "field_value").Info("Some info")
+	log.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
+	log.WithError(ctx, ErrSome).Error("Error occurred")
 }

--- a/adapter/internal/benchmark/benchmark.go
+++ b/adapter/internal/benchmark/benchmark.go
@@ -28,7 +28,7 @@ func Adapter(b *testing.B, adapter logger.Adapter) {
 	})
 
 	b.Run("local logger info", func(b *testing.B) {
-		localLogger := logger.Local(adapter)
+		localLogger := logger.Local{Adapter: adapter}
 
 		b.ReportAllocs()
 		b.ResetTimer()

--- a/adapter/log15adapter/_example/main.go
+++ b/adapter/log15adapter/_example/main.go
@@ -17,10 +17,10 @@ func main() {
 
 	l := log15.New()                           // create log15 logger
 	adapter := log15adapter.Adapter{Logger: l} // create logger.Adapter for log15
-	yalaLogger := logger.Local(adapter)        // create yala logger
+	log := logger.Local{Adapter: adapter}      // create yala logger
 
-	yalaLogger.Debug(ctx, "Hello log15")
-	yalaLogger.With(ctx, "field_name", "field_value").Info("Some info")
-	yalaLogger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	yalaLogger.WithError(ctx, ErrSome).Error("Some error")
+	log.Debug(ctx, "Hello log15")
+	log.With(ctx, "field_name", "field_value").Info("Some info")
+	log.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
+	log.WithError(ctx, ErrSome).Error("Some error")
 }

--- a/adapter/logrusadapter/_example/main.go
+++ b/adapter/logrusadapter/_example/main.go
@@ -22,12 +22,12 @@ func main() {
 		Entry: entry, // inject logrus
 	}
 	// Create yala logger
-	yalaLogger := logger.Local(adapter)
+	log := logger.Local{Adapter: adapter}
 
-	yalaLogger.Debug(ctx, "Hello logrus ")
-	yalaLogger.With(ctx, "field_name", "field_value").With("another", "ccc").Info("Some info")
-	yalaLogger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	yalaLogger.WithError(ctx, ErrSome).Error("Some error")
+	log.Debug(ctx, "Hello logrus ")
+	log.With(ctx, "field_name", "field_value").With("another", "ccc").Info("Some info")
+	log.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
+	log.WithError(ctx, ErrSome).Error("Some error")
 }
 
 func newLogrusEntry() *logrus.Entry {

--- a/adapter/printer/_example/main.go
+++ b/adapter/printer/_example/main.go
@@ -17,7 +17,7 @@ func main() {
 	ctx := context.Background()
 
 	// log using fmt.Println
-	yalaLogger := logger.Local(printer.StdoutAdapter())
+	yalaLogger := logger.Local{Adapter: printer.StdoutAdapter()}
 
 	yalaLogger.Debug(ctx, "Hello fmt")
 	yalaLogger.With(ctx, "field_name", "field_value").Info("Some info")
@@ -27,7 +27,7 @@ func main() {
 	// log using standard log package
 	standardLog := log.New(os.Stdout, "", log.LstdFlags)
 	adapter := printer.Adapter{Printer: standardLog}
-	yalaLogger = logger.Local(adapter)
+	yalaLogger = logger.Local{Adapter: adapter}
 
 	yalaLogger.Debug(ctx, "Hello standard log")
 	yalaLogger.With(ctx, "f1", "v1").With("f2", "f2").Info("Some info")

--- a/adapter/zapadapter/_example/main.go
+++ b/adapter/zapadapter/_example/main.go
@@ -18,12 +18,12 @@ func main() {
 
 	zapLogger := newZapLogger()
 	adapter := zapadapter.Adapter{Logger: zapLogger} // create logger.Adapter for zap
-	yalaLogger := logger.Local(adapter)              // Create yala logger
+	log := logger.Local{Adapter: adapter}            // Create yala logger
 
-	yalaLogger.Debug(ctx, "Hello zap")
-	yalaLogger.With(ctx, "field_name", "field_value").Info("Some info")
-	yalaLogger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	yalaLogger.WithError(ctx, ErrSome).Error("Some error")
+	log.Debug(ctx, "Hello zap")
+	log.With(ctx, "field_name", "field_value").Info("Some info")
+	log.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
+	log.WithError(ctx, ErrSome).Error("Some error")
 }
 
 func newZapLogger() *zap.Logger {

--- a/adapter/zerologadapter/_example/main.go
+++ b/adapter/zerologadapter/_example/main.go
@@ -18,10 +18,10 @@ func main() {
 
 	l := zerolog.New(os.Stdout)                  // create zerolog logger
 	adapter := zerologadapter.Adapter{Logger: l} // create logger.Adapter for zerolog
-	yalaLogger := logger.Local(adapter)          // Create yala logger
+	log := logger.Local{Adapter: adapter}        // Create yala logger
 
-	yalaLogger.Debug(ctx, "Hello zerolog")
-	yalaLogger.With(ctx, "field_name", "field_value").Info("Some info")
-	yalaLogger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	yalaLogger.WithError(ctx, ErrSome).Error("Some error")
+	log.Debug(ctx, "Hello zerolog")
+	log.With(ctx, "field_name", "field_value").Info("Some info")
+	log.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
+	log.WithError(ctx, ErrSome).Error("Some error")
 }

--- a/logger/_examples/contextlogger/main.go
+++ b/logger/_examples/contextlogger/main.go
@@ -21,7 +21,7 @@ func main() {
 	// this adapter will look for zap logger in the context and will wrap it with zapadapter.Adapter
 	adapter := ZapContextAdapter{DefaultZapLogger: defaultZapLogger}
 	// create local logger
-	log := logger.Local(adapter)
+	log := logger.Local{Adapter: adapter}
 
 	contextLogger := defaultZapLogger.With(zap.String("tag", "value"))
 	// bind zap logger to ctx, so all messages will be logged with tag

--- a/logger/_examples/filter/main.go
+++ b/logger/_examples/filter/main.go
@@ -17,7 +17,7 @@ func main() {
 		Prefix:      "example:",
 		NextAdapter: adapter,
 	}
-	l := logger.Local(filterAdapter)
+	l := logger.Local{Adapter: filterAdapter}
 
 	ctx := context.Background()
 

--- a/logger/_examples/tags/main.go
+++ b/logger/_examples/tags/main.go
@@ -15,7 +15,7 @@ func main() {
 
 	// creates an adapter which adds field from context to each logged message.
 	addFieldAdapter := AddFieldFromContextAdapter{NextAdapter: adapter}
-	l := logger.Local(addFieldAdapter)
+	l := logger.Local{Adapter: addFieldAdapter}
 
 	ctx := context.Background()
 	// add tag to context

--- a/logger/global.go
+++ b/logger/global.go
@@ -29,13 +29,13 @@ func (g *Global) SetAdapter(adapter Adapter) {
 		adapter = noopAdapter{}
 	}
 
-	g.logger.Store(LocalLogger{adapter: adapter})
+	g.logger.Store(Local{Adapter: adapter})
 }
 
-func (g *Global) getLogger() LocalLogger {
-	logger, ok := g.logger.Load().(LocalLogger)
+func (g *Global) getLogger() Local {
+	logger, ok := g.logger.Load().(Local)
 	if !ok {
-		g.logger.CompareAndSwap(nil, LocalLogger{adapter: &initialGlobalNoopAdapter{}})
+		g.logger.CompareAndSwap(nil, Local{Adapter: &initialGlobalNoopAdapter{}})
 
 		return g.getLogger()
 	}

--- a/logger/local.go
+++ b/logger/local.go
@@ -9,65 +9,54 @@ import (
 
 const localLoggerSkippedCallerFrames = 3
 
-// LocalLogger is an immutable struct to log messages or create new loggers with fields or error.
+// Local is an immutable struct to log messages or create new loggers with fields or error.
 //
 // It is safe to use it concurrently.
-type LocalLogger struct {
-	adapter Adapter
+type Local struct {
+	Adapter Adapter
 }
 
-// Local creates a new LocalLogger.
-func Local(adapter Adapter) LocalLogger {
-	if adapter == nil {
-		adapter = noopAdapter{}
-	}
-
-	return LocalLogger{
-		adapter: adapter,
-	}
-}
-
-func (l LocalLogger) Debug(ctx context.Context, msg string) {
+func (l Local) Debug(ctx context.Context, msg string) {
 	l.log(ctx, DebugLevel, msg)
 }
 
-func (l LocalLogger) log(ctx context.Context, lvl Level, msg string) {
-	if l.adapter == nil {
+func (l Local) log(ctx context.Context, lvl Level, msg string) {
+	if l.Adapter == nil {
 		return
 	}
 
-	l.adapter.Log(ctx, Entry{Level: lvl, Message: msg, SkippedCallerFrames: localLoggerSkippedCallerFrames})
+	l.Adapter.Log(ctx, Entry{Level: lvl, Message: msg, SkippedCallerFrames: localLoggerSkippedCallerFrames})
 }
 
-func (l LocalLogger) Info(ctx context.Context, msg string) {
+func (l Local) Info(ctx context.Context, msg string) {
 	l.log(ctx, InfoLevel, msg)
 }
 
-func (l LocalLogger) Warn(ctx context.Context, msg string) {
+func (l Local) Warn(ctx context.Context, msg string) {
 	l.log(ctx, WarnLevel, msg)
 }
 
-func (l LocalLogger) Error(ctx context.Context, msg string) {
+func (l Local) Error(ctx context.Context, msg string) {
 	l.log(ctx, ErrorLevel, msg)
 }
 
 // With creates a new Logger with field.
-func (l LocalLogger) With(ctx context.Context, key string, value interface{}) Logger {
+func (l Local) With(ctx context.Context, key string, value interface{}) Logger {
 	return l.logger(ctx).With(key, value)
 }
 
-func (l LocalLogger) logger(ctx context.Context) Logger {
+func (l Local) logger(ctx context.Context) Logger {
 	return Logger{
-		adapter: l.adapter,
+		adapter: l.Adapter,
 		ctx:     ctx,
 	}
 }
 
 // WithError creates a new Logger with error.
-func (l LocalLogger) WithError(ctx context.Context, err error) Logger {
+func (l Local) WithError(ctx context.Context, err error) Logger {
 	return l.logger(ctx).WithError(err)
 }
 
-func (l LocalLogger) WithSkippedCallerFrame(ctx context.Context) Logger {
+func (l Local) WithSkippedCallerFrame(ctx context.Context) Logger {
 	return l.logger(ctx).WithSkippedCallerFrame()
 }

--- a/logger/logger_concurrency_test.go
+++ b/logger/logger_concurrency_test.go
@@ -42,7 +42,7 @@ func TestConcurrency(t *testing.T) {
 
 	t.Run("local log functions", func(t *testing.T) {
 		adapter := &concurrencySafeAdapter{}
-		localLogger := logger.Local(adapter)
+		localLogger := logger.Local{Adapter: adapter}
 
 		var wg sync.WaitGroup
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -87,24 +87,24 @@ func TestGlobalLogging(t *testing.T) {
 
 func TestLocalLogger(t *testing.T) {
 	t.Run("passing nil adapter should disable logger", func(t *testing.T) {
-		localLogger := logger.Local(nil)
+		localLogger := logger.Local{Adapter: nil}
 		localLogger.Info(ctx, message)
 	})
 
 	t.Run("using zero value should not panic", func(t *testing.T) {
-		var localLogger logger.LocalLogger
+		var localLogger logger.Local
 		assert.NotPanics(t, func() {
 			localLogger.Info(ctx, message)
 		})
 	})
 
 	t.Run("should log message using adapter", func(t *testing.T) {
-		type functionUnderTest func(l logger.LocalLogger, ctx context.Context, msg string)
+		type functionUnderTest func(l logger.Local, ctx context.Context, msg string)
 		tests := map[logger.Level]functionUnderTest{
-			logger.DebugLevel: logger.LocalLogger.Debug,
-			logger.InfoLevel:  logger.LocalLogger.Info,
-			logger.WarnLevel:  logger.LocalLogger.Warn,
-			logger.ErrorLevel: logger.LocalLogger.Error,
+			logger.DebugLevel: logger.Local.Debug,
+			logger.InfoLevel:  logger.Local.Info,
+			logger.WarnLevel:  logger.Local.Warn,
+			logger.ErrorLevel: logger.Local.Error,
 		}
 
 		for lvl, log := range tests {
@@ -112,7 +112,7 @@ func TestLocalLogger(t *testing.T) {
 
 			t.Run(testName, func(t *testing.T) {
 				adapter := &adapterMock{}
-				localLogger := logger.Local(adapter)
+				localLogger := logger.Local{Adapter: adapter}
 				// when
 				log(localLogger, context.Background(), message)
 				// then
@@ -139,7 +139,7 @@ func TestWith(t *testing.T) {
 			return global.With(ctx, field.Key, field.Value)
 		},
 		"local": func(adapter logger.Adapter, field logger.Field) logger.Logger {
-			return logger.Local(adapter).With(ctx, field.Key, field.Value)
+			return logger.Local{Adapter: adapter}.With(ctx, field.Key, field.Value)
 		},
 	}
 
@@ -199,7 +199,7 @@ func TestWithError(t *testing.T) {
 			return global.WithError(ctx, err)
 		},
 		"local": func(adapter logger.Adapter, err error) logger.Logger {
-			return logger.Local(adapter).WithError(ctx, err)
+			return logger.Local{Adapter: adapter}.WithError(ctx, err)
 		},
 	}
 	for name, newLogger := range loggersWithError {


### PR DESCRIPTION
At the moment logger.Local(adapter) is a constructor creating LocalLogger instance. This constructor does not do anything special. That's why it is not needed.

Also, other structures in yala (adapters) are initialized using struct literal. So using a function constructor is not very intuitive.

Also, global logger is named logger.Global. So local one should be named logger.Local.