### PR TITLE
[logfmt] Change formatting

### DIFF
--- a/adapter/logfmt/logfmt.go
+++ b/adapter/logfmt/logfmt.go
@@ -30,7 +30,7 @@ func writeValue(builder *strings.Builder, value interface{}) {
 		return
 	}
 
-	valueStr := fmt.Sprintf("%s", value)
+	valueStr := fmt.Sprintf("%+v", value)
 
 	if strings.ContainsRune(valueStr, '\\') {
 		valueStr = strings.ReplaceAll(valueStr, `\`, `\\`)

--- a/adapter/logfmt/logfmt_test.go
+++ b/adapter/logfmt/logfmt_test.go
@@ -6,6 +6,7 @@ package logfmt_test
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/elgopher/yala/adapter/logfmt"
 	"github.com/elgopher/yala/logger"
@@ -57,6 +58,56 @@ func TestWriteField(t *testing.T) {
 			`"quoted with spaces"`: {
 				field:    field("k", `"quoted with spaces"`),
 				expected: `k="\"quoted with spaces\""`,
+			},
+			"int value": {
+				field:    field("k", 1),
+				expected: "k=1",
+			},
+			"float value": {
+				field:    field("k", 2.1),
+				expected: "k=2.1",
+			},
+			"time value": {
+				field:    field("k", time.Time{}),
+				expected: `k="0001-01-01 00:00:00 +0000 UTC"`,
+			},
+			"slice": {
+				field:    field("k", []string{"a"}),
+				expected: `k=[a]`,
+			},
+			"slice with two values": {
+				field:    field("k", []string{"a", "b"}),
+				expected: `k="[a b]"`,
+			},
+			"map": {
+				field:    field("k", map[string]string{"a": "b"}),
+				expected: `k=map[a:b]`,
+			},
+			"map with two values": {
+				field:    field("k", map[string]string{"a": "b", "b": "c"}),
+				expected: `k="map[a:b b:c]"`,
+			},
+			"struct value": {
+				field: field("k",
+					struct {
+						Property string
+					}{
+						Property: "a",
+					},
+				),
+				expected: "k={Property:a}",
+			},
+			"struct value with two properties": {
+				field: field("k",
+					struct {
+						Property1 string
+						Property2 string
+					}{
+						Property1: "a",
+						Property2: "b",
+					},
+				),
+				expected: `k="{Property1:a Property2:b}"`,
 			},
 		}
 		for name, test := range tests {

--- a/logger/_examples/reuse/main.go
+++ b/logger/_examples/reuse/main.go
@@ -17,6 +17,6 @@ func main() {
 	requestLogger := log.With(ctx, "request_id", "123").With("user", "elgopher")
 
 	requestLogger.Debug("request started")
-	requestLogger.With("table", "gophers").Debug("sql update executed")
+	requestLogger.With("rows_updated", 3).With("table", "gophers").Debug("sql update executed")
 	requestLogger.Debug("request finished")
 }


### PR DESCRIPTION
Change formatting of numbers, slices, maps and structs.

Use fmt.Sprintf("%+v") instead of fmt.Sprintf("%s")