### PR TITLE
[log] Fix caller information presented by logadapter

### DIFF
--- a/adapter/console/console.go
+++ b/adapter/console/console.go
@@ -26,10 +26,10 @@ type WriterPrinter struct {
 	Writer io.Writer
 }
 
-func (p WriterPrinter) Println(args ...interface{}) {
+func (p WriterPrinter) Println(skipCallerFrames int, msg string) {
 	if p.Writer == nil {
 		return
 	}
 
-	_, _ = fmt.Fprintln(p.Writer, args...)
+	_, _ = fmt.Fprintln(p.Writer, msg)
 }

--- a/adapter/console/console_test.go
+++ b/adapter/console/console_test.go
@@ -14,7 +14,7 @@ func TestWriterPrinter_Println(t *testing.T) {
 	t.Run("should not panic when Writer is nil", func(t *testing.T) {
 		p := console.WriterPrinter{Writer: nil}
 		assert.NotPanics(t, func() {
-			p.Println("")
+			p.Println(0, "")
 		})
 	})
 }

--- a/adapter/internal/benchmark/RESULTS.md
+++ b/adapter/internal/benchmark/RESULTS.md
@@ -6,14 +6,14 @@ are useful for performance regression testing.
 * cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
 
 ```
-BenchmarkConsole/global_logger_info-8         	 8403124	       140.6 ns/op	      40 B/op	       3 allocs/op
-BenchmarkConsole/local_logger_info-8          	 9990122	       123.8 ns/op	      40 B/op	       3 allocs/op
-BenchmarkConsole/time/local_logger_with_field-8         	 1761192	       691.3 ns/op	     200 B/op	       8 allocs/op
-BenchmarkConsole/string/local_logger_with_field-8       	 4456893	       297.5 ns/op	      96 B/op	       6 allocs/op
-BenchmarkConsole/int/local_logger_with_field-8          	 4396735	       279.8 ns/op	      88 B/op	       5 allocs/op
-BenchmarkConsole/int64/local_logger_with_field-8        	 4330046	       277.9 ns/op	      96 B/op	       6 allocs/op
-BenchmarkConsole/float64/local_logger_with_field-8      	 3428498	       357.2 ns/op	      96 B/op	       6 allocs/op
-BenchmarkConsole/float32/local_logger_with_field-8      	 3494066	       345.2 ns/op	      96 B/op	       6 allocs/op
+BenchmarkConsole/global_logger_info-8         	 9950290	       118.6 ns/op	      24 B/op	       2 allocs/op
+BenchmarkConsole/local_logger_info-8          	12217653	        98.95 ns/op	      24 B/op	       2 allocs/op
+BenchmarkConsole/string/local_logger_with_field-8         	 4732758	       263.1 ns/op	      80 B/op	       5 allocs/op
+BenchmarkConsole/int/local_logger_with_field-8            	 4716872	       249.8 ns/op	      72 B/op	       4 allocs/op
+BenchmarkConsole/int64/local_logger_with_field-8          	 4554200	       260.3 ns/op	      80 B/op	       5 allocs/op
+BenchmarkConsole/float64/local_logger_with_field-8        	 3592687	       333.5 ns/op	      80 B/op	       5 allocs/op
+BenchmarkConsole/float32/local_logger_with_field-8        	 3695378	       324.5 ns/op	      80 B/op	       5 allocs/op
+BenchmarkConsole/time/local_logger_with_field-8           	 1791531	       659.0 ns/op	     184 B/op	       7 allocs/op
 BenchmarkGlog/global_logger_info-8         	 1000000	      1131 ns/op	     232 B/op	       3 allocs/op
 BenchmarkGlog/local_logger_info-8          	 1000000	      1012 ns/op	     232 B/op	       3 allocs/op
 BenchmarkGlog/int64/local_logger_with_field-8         	  932733	      1293 ns/op	     296 B/op	       7 allocs/op

--- a/adapter/logadapter/_example/main.go
+++ b/adapter/logadapter/_example/main.go
@@ -17,7 +17,7 @@ func main() {
 	ctx := context.Background()
 
 	// log using standard log package
-	standardLog := log.New(os.Stdout, "", log.LstdFlags)
+	standardLog := log.New(os.Stdout, "", log.LstdFlags|log.Lshortfile)
 	adapter := logadapter.Adapter(standardLog)
 	yalaLogger := logger.Local{Adapter: adapter}
 

--- a/adapter/logadapter/logadapter.go
+++ b/adapter/logadapter/logadapter.go
@@ -8,5 +8,13 @@ import (
 )
 
 func Adapter(l *log.Logger) logger.Adapter { // nolint
-	return printer.Adapter{Printer: l}
+	return printer.Adapter{Printer: printerLogger{l}}
+}
+
+type printerLogger struct {
+	*log.Logger
+}
+
+func (p printerLogger) Println(skipCallerFrames int, msg string) {
+	_ = p.Logger.Output(skipCallerFrames+1, msg)
 }

--- a/adapter/logadapter/logadapter_bench_test.go
+++ b/adapter/logadapter/logadapter_bench_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 
 	"github.com/elgopher/yala/adapter/internal/benchmark"
-	"github.com/elgopher/yala/adapter/printer"
+	"github.com/elgopher/yala/adapter/logadapter"
 )
 
 func BenchmarkLog(b *testing.B) {
 	standardLog := log.New(benchmark.DiscardWriter{}, "", log.LstdFlags)
-	adapter := printer.Adapter{Printer: standardLog}
+	adapter := logadapter.Adapter(standardLog)
 	benchmark.Adapter(b, adapter)
 }

--- a/adapter/printer/printer.go
+++ b/adapter/printer/printer.go
@@ -22,7 +22,7 @@ type Adapter struct {
 }
 
 type Printer interface {
-	Println(...interface{})
+	Println(skipCallerFrames int, msg string)
 }
 
 func (f Adapter) Log(ctx context.Context, entry logger.Entry) {
@@ -46,5 +46,5 @@ func (f Adapter) Log(ctx context.Context, entry logger.Entry) {
 		logfmt.WriteField(&builder, logger.Field{Key: "error", Value: entry.Error})
 	}
 
-	f.Printer.Println(builder.String())
+	f.Printer.Println(entry.SkippedCallerFrames+1, builder.String())
 }

--- a/adapter/printer/printer_test.go
+++ b/adapter/printer/printer_test.go
@@ -97,7 +97,7 @@ type stringPrinter struct {
 	io.StringWriter
 }
 
-func (p stringPrinter) Println(i ...interface{}) {
-	s := fmt.Sprintln(i...)
+func (p stringPrinter) Println(_ int, msg string) {
+	s := fmt.Sprintln(msg)
 	_, _ = p.WriteString(s)
 }


### PR DESCRIPTION
At the moment the caller printed in logs is some frame from yala internals, not the real caller.

Change Printer.Println method signature, so the logadapter can pass the depth. Plus Println accepts varargs even though it is not used. Using string will be faster (less allocations).