### PR TITLE
Change type of logger.Level to int8

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ func (MyAdapter) Log(context.Context, logger.Entry) {
 ### Advanced recipes
 
 * [Filter out messages starting with given prefix](logger/_examples/filter/main.go)
+* [Filter messages by level](logger/_examples/levelfilter/main.go)
 * [Add field to each message taken from context.Context](logger/_examples/tags/main.go)
 * [Zap logger passed over context.Context](logger/_examples/contextlogger/main.go)
 

--- a/adapter/log15adapter/log15_test.go
+++ b/adapter/log15adapter/log15_test.go
@@ -29,7 +29,7 @@ func TestAdapter_Log(t *testing.T) {
 		}
 
 		for level, log15level := range tests {
-			t.Run(string(level), func(t *testing.T) {
+			t.Run(level.String(), func(t *testing.T) {
 				log15Logger := log15.New()
 				handler := &handlerMock{}
 				log15Logger.SetHandler(handler)

--- a/adapter/printer/printer.go
+++ b/adapter/printer/printer.go
@@ -31,7 +31,7 @@ func (f Adapter) Log(ctx context.Context, entry logger.Entry) {
 
 	var builder strings.Builder
 
-	builder.WriteString(string(entry.Level))
+	builder.WriteString(entry.Level.String())
 	builder.WriteByte(' ')
 	builder.WriteString(entry.Message)
 

--- a/logger/_examples/levelfilter/main.go
+++ b/logger/_examples/levelfilter/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+
+	"github.com/elgopher/yala/adapter/console"
+	"github.com/elgopher/yala/logger"
+)
+
+// This advanced example shows how to filter logs by level (if the library of your choice does not support that,
+// or you want to use different filtering for different loggers).
+func main() {
+	adapter := console.StdoutAdapter()
+
+	// creates an adapter which filters logs by level
+	filterAdapter := FilterByLevel{
+		MinLevel:    logger.WarnLevel,
+		NextAdapter: adapter,
+	}
+	l := logger.Local{Adapter: filterAdapter}
+
+	ctx := context.Background()
+
+	l.Info(ctx, "will be filtered out")
+	l.Warn(ctx, "will be logged")
+	l.Error(ctx, "this too will be logged")
+}
+
+// FilterByLevel is a middleware (decorator) which filters out entries
+// with level less severe than MinLevel
+type FilterByLevel struct {
+	MinLevel    logger.Level
+	NextAdapter logger.Adapter
+}
+
+func (a FilterByLevel) Log(ctx context.Context, entry logger.Entry) {
+	// It is always better to use MoreSevereThan method instead of directly comparing integers,
+	// because it hides out how levels are sorted
+	if a.MinLevel.MoreSevereThan(entry.Level) {
+		return
+	}
+
+	entry.SkippedCallerFrames++ // each middleware adapter must additionally skip one frame
+	a.NextAdapter.Log(ctx, entry)
+}

--- a/logger/adapter.go
+++ b/logger/adapter.go
@@ -5,6 +5,7 @@ package logger
 
 import (
 	"context"
+	"strconv"
 )
 
 // Adapter is an interface to be implemented by logger adapters.
@@ -32,14 +33,33 @@ func (e Entry) With(field Field) Entry {
 	return e
 }
 
-type Level string
+type Level int8
 
 const (
-	DebugLevel Level = "DEBUG"
-	InfoLevel  Level = "INFO"
-	WarnLevel  Level = "WARN"
-	ErrorLevel Level = "ERROR"
+	DebugLevel Level = iota - 1
+	InfoLevel
+	WarnLevel
+	ErrorLevel
 )
+
+func (l Level) String() string {
+	switch l {
+	case DebugLevel:
+		return "DEBUG"
+	case InfoLevel:
+		return "INFO"
+	case WarnLevel:
+		return "WARN"
+	case ErrorLevel:
+		return "ERROR"
+	default:
+		return strconv.Itoa(int(l))
+	}
+}
+
+func (l Level) MoreSevereThan(other Level) bool {
+	return l > other
+}
 
 type Field struct {
 	Key   string

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -65,7 +65,7 @@ func TestGlobalLogging(t *testing.T) {
 		}
 
 		for lvl, log := range tests {
-			testName := string(lvl)
+			testName := lvl.String()
 
 			t.Run(testName, func(t *testing.T) {
 				adapter := &adapterMock{}
@@ -108,7 +108,7 @@ func TestLocalLogger(t *testing.T) {
 		}
 
 		for lvl, log := range tests {
-			testName := string(lvl)
+			testName := lvl.String()
 
 			t.Run(testName, func(t *testing.T) {
 				adapter := &adapterMock{}
@@ -253,5 +253,43 @@ func TestEntry_With(t *testing.T) {
 		assert.Equal(t, entry.Fields[0], field1)
 		assert.Equal(t, newEntry.Fields[0], field1)
 		assert.Equal(t, newEntry.Fields[1], field2)
+	})
+}
+
+func TestLevel_MoreSevereThan(t *testing.T) {
+	t.Run("should return true", func(t *testing.T) {
+		assert.True(t, logger.InfoLevel.MoreSevereThan(logger.DebugLevel))
+		assert.True(t, logger.WarnLevel.MoreSevereThan(logger.DebugLevel))
+		assert.True(t, logger.ErrorLevel.MoreSevereThan(logger.DebugLevel))
+
+		assert.True(t, logger.WarnLevel.MoreSevereThan(logger.InfoLevel))
+		assert.True(t, logger.ErrorLevel.MoreSevereThan(logger.InfoLevel))
+
+		assert.True(t, logger.ErrorLevel.MoreSevereThan(logger.WarnLevel))
+	})
+
+	t.Run("should return false", func(t *testing.T) {
+		assert.False(t, logger.DebugLevel.MoreSevereThan(logger.DebugLevel))
+
+		assert.False(t, logger.DebugLevel.MoreSevereThan(logger.InfoLevel))
+		assert.False(t, logger.InfoLevel.MoreSevereThan(logger.InfoLevel))
+
+		assert.False(t, logger.DebugLevel.MoreSevereThan(logger.WarnLevel))
+		assert.False(t, logger.InfoLevel.MoreSevereThan(logger.WarnLevel))
+		assert.False(t, logger.WarnLevel.MoreSevereThan(logger.WarnLevel))
+
+		assert.False(t, logger.DebugLevel.MoreSevereThan(logger.ErrorLevel))
+		assert.False(t, logger.InfoLevel.MoreSevereThan(logger.ErrorLevel))
+		assert.False(t, logger.WarnLevel.MoreSevereThan(logger.ErrorLevel))
+		assert.False(t, logger.ErrorLevel.MoreSevereThan(logger.ErrorLevel))
+	})
+}
+
+func TestLevel_String(t *testing.T) {
+	t.Run("should convert to string", func(t *testing.T) {
+		assert.Equal(t, "DEBUG", logger.DebugLevel.String())
+		assert.Equal(t, "INFO", logger.InfoLevel.String())
+		assert.Equal(t, "WARN", logger.WarnLevel.String())
+		assert.Equal(t, "ERROR", logger.ErrorLevel.String())
 	})
 }


### PR DESCRIPTION
This change will make it possible to compare levels. It is useful in adapters filtering by minimum level.

The old string representation will be available via new method `Level.String()`