### PR TITLE
Move context.Context parameter to Info method

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ func SetLoggerAdapter(adapter logger.Adapter) {
 
 func Function(ctx context.Context) {
 	log.Debug(ctx, "Debug message")
-	log.With(ctx, "field_name", "value").Info("Message with field")
-	log.WithError(ctx, errors.New("some")).Error("Message with error")
+	log.With("field_name", "value").Info(ctx, "Message with field")
+	log.WithError(errors.New("some")).Error(ctx, "Message with error")
 }
 ```
 

--- a/adapter/console/_example/main.go
+++ b/adapter/console/_example/main.go
@@ -18,7 +18,7 @@ func main() {
 	log := logger.Local{Adapter: console.StdoutAdapter()}
 
 	log.Debug(ctx, "Hello fmt")
-	log.With(ctx, "field_name", "field_value").Info("Some info")
-	log.With(ctx, "parameter", "some value").Warn("Deprecated configuration parameter. It will be removed.")
-	log.WithError(ctx, ErrSome).Error("Some error")
+	log.With("field_name", "field_value").Info(ctx, "Some info")
+	log.With("parameter", "some value").Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	log.WithError(ErrSome).Error(ctx, "Some error")
 }

--- a/adapter/glogadapter/_example/main.go
+++ b/adapter/glogadapter/_example/main.go
@@ -20,7 +20,7 @@ func main() {
 	log := logger.Local{Adapter: glogadapter.Adapter{}}
 
 	log.Debug(ctx, "Hello glog ") // Debug will be logged as Info
-	log.With(ctx, "field_name", "field_value").Info("Some info")
-	log.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	log.WithError(ctx, ErrSome).Error("Error occurred")
+	log.With("field_name", "field_value").Info(ctx, "Some info")
+	log.With("parameter", "some").Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	log.WithError(ErrSome).Error(ctx, "Error occurred")
 }

--- a/adapter/internal/benchmark/benchmark.go
+++ b/adapter/internal/benchmark/benchmark.go
@@ -57,7 +57,7 @@ func Adapter(b *testing.B, adapter logger.Adapter) {
 				b.ResetTimer()
 
 				for i := 0; i < b.N; i++ {
-					localLogger.With(ctx, "a", fieldValue).Info("msg")
+					localLogger.With("a", fieldValue).Info(ctx, "msg")
 				}
 			})
 		})

--- a/adapter/log15adapter/_example/main.go
+++ b/adapter/log15adapter/_example/main.go
@@ -20,7 +20,7 @@ func main() {
 	log := logger.Local{Adapter: adapter}      // create yala logger
 
 	log.Debug(ctx, "Hello log15")
-	log.With(ctx, "field_name", "field_value").Info("Some info")
-	log.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	log.WithError(ctx, ErrSome).Error("Some error")
+	log.With("field_name", "field_value").Info(ctx, "Some info")
+	log.With("parameter", "some").Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	log.WithError(ErrSome).Error(ctx, "Some error")
 }

--- a/adapter/logadapter/_example/main.go
+++ b/adapter/logadapter/_example/main.go
@@ -22,7 +22,7 @@ func main() {
 	yalaLogger := logger.Local{Adapter: adapter}
 
 	yalaLogger.Debug(ctx, "Hello standard log")
-	yalaLogger.With(ctx, "f1", "v1").With("f2", "f2").Info("Some info")
-	yalaLogger.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	yalaLogger.WithError(ctx, ErrSome).Error("Some error")
+	yalaLogger.With("f1", "v1").With("f2", "f2").Info(ctx, "Some info")
+	yalaLogger.With("parameter", "some").Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	yalaLogger.WithError(ErrSome).Error(ctx, "Some error")
 }

--- a/adapter/logrusadapter/_example/main.go
+++ b/adapter/logrusadapter/_example/main.go
@@ -25,9 +25,9 @@ func main() {
 	log := logger.Local{Adapter: adapter}
 
 	log.Debug(ctx, "Hello logrus ")
-	log.With(ctx, "field_name", "field_value").With("another", "ccc").Info("Some info")
-	log.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	log.WithError(ctx, ErrSome).Error("Some error")
+	log.With("field_name", "field_value").With("another", "ccc").Info(ctx, "Some info")
+	log.With("parameter", "some").Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	log.WithError(ErrSome).Error(ctx, "Some error")
 }
 
 func newLogrusEntry() *logrus.Entry {

--- a/adapter/zapadapter/_example/main.go
+++ b/adapter/zapadapter/_example/main.go
@@ -21,9 +21,9 @@ func main() {
 	log := logger.Local{Adapter: adapter}            // Create yala logger
 
 	log.Debug(ctx, "Hello zap")
-	log.With(ctx, "field_name", "field_value").Info("Some info")
-	log.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	log.WithError(ctx, ErrSome).Error("Some error")
+	log.With("field_name", "field_value").Info(ctx, "Some info")
+	log.With("parameter", "some").Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	log.WithError(ErrSome).Error(ctx, "Some error")
 }
 
 func newZapLogger() *zap.Logger {

--- a/adapter/zerologadapter/_example/main.go
+++ b/adapter/zerologadapter/_example/main.go
@@ -21,7 +21,7 @@ func main() {
 	log := logger.Local{Adapter: adapter}        // Create yala logger
 
 	log.Debug(ctx, "Hello zerolog")
-	log.With(ctx, "field_name", "field_value").Info("Some info")
-	log.With(ctx, "parameter", "some").Warn("Deprecated configuration parameter. It will be removed.")
-	log.WithError(ctx, ErrSome).Error("Some error")
+	log.With("field_name", "field_value").Info(ctx, "Some info")
+	log.With("parameter", "some").Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	log.WithError(ErrSome).Error(ctx, "Some error")
 }

--- a/logger/_examples/reuse/main.go
+++ b/logger/_examples/reuse/main.go
@@ -14,9 +14,9 @@ func main() {
 	log := logger.Local{Adapter: console.StdoutAdapter()}
 
 	// requestLogger will log all messages with at least two fields: request_id and user
-	requestLogger := log.With(ctx, "request_id", "123").With("user", "elgopher")
+	requestLogger := log.With("request_id", "123").With("user", "elgopher")
 
-	requestLogger.Debug("request started")
-	requestLogger.With("rows_updated", 3).With("table", "gophers").Debug("sql update executed")
-	requestLogger.Debug("request finished")
+	requestLogger.Debug(ctx, "request started")
+	requestLogger.With("rows_updated", 3).With("table", "gophers").Debug(ctx, "sql update executed")
+	requestLogger.Debug(ctx, "request finished")
 }

--- a/logger/_examples/tags/main.go
+++ b/logger/_examples/tags/main.go
@@ -22,7 +22,7 @@ func main() {
 	ctx = context.WithValue(ctx, tag, "value")
 
 	l.Info(ctx, "tagged message")                // INFO tagged message tag=value
-	l.With(ctx, "k", "v").Info("tagged message") // INFO tagged message k=v tag=value
+	l.With("k", "v").Info(ctx, "tagged message") // INFO tagged message k=v tag=value
 }
 
 // AddFieldFromContextAdapter is a middleware (decorator) which adds

--- a/logger/global.go
+++ b/logger/global.go
@@ -12,8 +12,11 @@ import (
 //
 //		package yourpackage
 //		import "github.com/elgopher/yala/logger"
-//		var Logger logger.Global // define global logger, no need to initialize (by default nothing is logged)
+//		var log logger.Global // define global logger, no need to initialize (by default nothing is logged)
 //
+//		func SetLoggerAdapter(adapter logger.Adapter) {
+//			log.SetAdapter(adapter)
+//		}
 //
 // It is safe to use it concurrently.
 type Global struct {
@@ -45,34 +48,34 @@ func (g *Global) getLogger() Local {
 
 // Debug logs message using globally configured logger.Adapter.
 func (g *Global) Debug(ctx context.Context, msg string) {
-	g.loggerWithSkippedCallerFrame(ctx).Debug(msg)
+	g.loggerWithSkippedCallerFrame().Debug(ctx, msg)
 }
 
-func (g *Global) loggerWithSkippedCallerFrame(ctx context.Context) Logger {
-	return g.getLogger().WithSkippedCallerFrame(ctx)
+func (g *Global) loggerWithSkippedCallerFrame() Logger {
+	return g.getLogger().WithSkippedCallerFrame()
 }
 
 // Info logs message using globally configured logger.Adapter.
 func (g *Global) Info(ctx context.Context, msg string) {
-	g.loggerWithSkippedCallerFrame(ctx).Info(msg)
+	g.loggerWithSkippedCallerFrame().Info(ctx, msg)
 }
 
 // Warn logs message using globally configured logger.Adapter.
 func (g *Global) Warn(ctx context.Context, msg string) {
-	g.loggerWithSkippedCallerFrame(ctx).Warn(msg)
+	g.loggerWithSkippedCallerFrame().Warn(ctx, msg)
 }
 
 // Error logs message using globally configured logger.Adapter.
 func (g *Global) Error(ctx context.Context, msg string) {
-	g.loggerWithSkippedCallerFrame(ctx).Error(msg)
+	g.loggerWithSkippedCallerFrame().Error(ctx, msg)
 }
 
 // With creates a new Logger with field and using globally configured logger.Adapter.
-func (g *Global) With(ctx context.Context, key string, value interface{}) Logger {
-	return g.getLogger().With(ctx, key, value)
+func (g *Global) With(key string, value interface{}) Logger {
+	return g.getLogger().With(key, value)
 }
 
 // WithError creates a new Logger with error and using globally configured logger.Adapter.
-func (g *Global) WithError(ctx context.Context, err error) Logger {
-	return g.getLogger().WithError(ctx, err)
+func (g *Global) WithError(err error) Logger {
+	return g.getLogger().WithError(err)
 }

--- a/logger/local.go
+++ b/logger/local.go
@@ -41,22 +41,21 @@ func (l Local) Error(ctx context.Context, msg string) {
 }
 
 // With creates a new Logger with field.
-func (l Local) With(ctx context.Context, key string, value interface{}) Logger {
-	return l.logger(ctx).With(key, value)
+func (l Local) With(key string, value interface{}) Logger {
+	return l.logger().With(key, value)
 }
 
-func (l Local) logger(ctx context.Context) Logger {
+func (l Local) logger() Logger {
 	return Logger{
 		adapter: l.Adapter,
-		ctx:     ctx,
 	}
 }
 
 // WithError creates a new Logger with error.
-func (l Local) WithError(ctx context.Context, err error) Logger {
-	return l.logger(ctx).WithError(err)
+func (l Local) WithError(err error) Logger {
+	return l.logger().WithError(err)
 }
 
-func (l Local) WithSkippedCallerFrame(ctx context.Context) Logger {
-	return l.logger(ctx).WithSkippedCallerFrame()
+func (l Local) WithSkippedCallerFrame() Logger {
+	return l.logger().WithSkippedCallerFrame()
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -24,7 +24,6 @@ import (
 type Logger struct {
 	entry   Entry
 	adapter Adapter
-	ctx     context.Context
 }
 
 // With creates a new Logger with field.
@@ -47,27 +46,27 @@ func (l Logger) WithSkippedCallerFrame() Logger {
 	return l
 }
 
-func (l Logger) Debug(msg string) {
-	l.log(DebugLevel, msg)
+func (l Logger) Debug(ctx context.Context, msg string) {
+	l.log(ctx, DebugLevel, msg)
 }
 
-func (l Logger) Info(msg string) {
-	l.log(InfoLevel, msg)
+func (l Logger) Info(ctx context.Context, msg string) {
+	l.log(ctx, InfoLevel, msg)
 }
 
-func (l Logger) Warn(msg string) {
-	l.log(WarnLevel, msg)
+func (l Logger) Warn(ctx context.Context, msg string) {
+	l.log(ctx, WarnLevel, msg)
 }
 
-func (l Logger) Error(msg string) {
-	l.log(ErrorLevel, msg)
+func (l Logger) Error(ctx context.Context, msg string) {
+	l.log(ctx, ErrorLevel, msg)
 }
 
-func (l Logger) log(level Level, msg string) {
+func (l Logger) log(ctx context.Context, level Level, msg string) {
 	e := l.entry
 	e.Level = level
 	e.Message = msg
 	e.SkippedCallerFrames += 3
 
-	l.adapter.Log(l.ctx, e)
+	l.adapter.Log(ctx, e)
 }

--- a/logger/logger_bench_test.go
+++ b/logger/logger_bench_test.go
@@ -15,7 +15,7 @@ func BenchmarkInfo(b *testing.B) {
 	var global logger.Global
 
 	for i := 0; i < b.N; i++ {
-		global.Info(ctx, "msg") // 27.5ns, 0 allocs
+		global.Info(ctx, "msg") // 25ns, 0 allocs
 	}
 }
 
@@ -24,20 +24,20 @@ func BenchmarkParallelInfo(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			global.Info(ctx, "msg") // 3.6 ns/op (8 goroutines, 8 cores)
+			global.Info(ctx, "msg") // 3.3 ns/op (8 goroutines, 8 cores)
 		}
 	})
 }
 
 func BenchmarkLogger_Info(b *testing.B) {
 	var global logger.Global
-	loggerWithField := global.With(ctx, "k", "v")
+	loggerWithField := global.With("k", "v")
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		loggerWithField.Info("msg") // 12ns, 0 allocs
+		loggerWithField.Info(ctx, "msg") // 9.5ns, 0 allocs
 	}
 }
 
@@ -47,7 +47,7 @@ func BenchmarkWith(b *testing.B) {
 	var global logger.Global
 
 	for i := 0; i < b.N; i++ {
-		_ = global.With(ctx, "k", "v") // 55ns, 1 alloc
+		_ = global.With("k", "v") // 50ns, 1 alloc
 	}
 }
 
@@ -57,6 +57,6 @@ func BenchmarkWithError(b *testing.B) {
 	var global logger.Global
 
 	for i := 0; i < b.N; i++ {
-		_ = global.WithError(ctx, ErrSome) // 15ns, 0 allocs
+		_ = global.WithError(ErrSome) // 12ns, 0 allocs
 	}
 }

--- a/logger/logger_concurrency_test.go
+++ b/logger/logger_concurrency_test.go
@@ -29,8 +29,8 @@ func TestConcurrency(t *testing.T) {
 				global.Info(ctx, message)
 				global.Warn(ctx, message)
 				global.Error(ctx, message)
-				global.With(ctx, "k", "v").Info(message)
-				global.WithError(ctx, ErrSome).Error(message)
+				global.With("k", "v").Info(ctx, message)
+				global.WithError(ErrSome).Error(ctx, message)
 				waitGroup.Done()
 			}()
 		}
@@ -55,8 +55,8 @@ func TestConcurrency(t *testing.T) {
 				localLogger.Info(ctx, message)
 				localLogger.Warn(ctx, message)
 				localLogger.Error(ctx, message)
-				localLogger.With(ctx, "k", "v").Info(message)
-				localLogger.WithError(ctx, ErrSome).Error(message)
+				localLogger.With("k", "v").Info(ctx, message)
+				localLogger.WithError(ErrSome).Error(ctx, message)
 				waitGroup.Done()
 			}()
 		}


### PR DESCRIPTION
context.Context should not be retained in other structures, because it makes user programs more complicated. context.Context should be passed to log methods such as Info, Debug, Warn and Error.