### PR TITLE
[log] Don't panic when *log.Logger is nil

### DIFF
--- a/adapter/logadapter/logadapter.go
+++ b/adapter/logadapter/logadapter.go
@@ -1,6 +1,7 @@
 package logadapter
 
 import (
+	"context"
 	"log"
 
 	"github.com/elgopher/yala/adapter/printer"
@@ -8,6 +9,10 @@ import (
 )
 
 func Adapter(l *log.Logger) logger.Adapter { // nolint
+	if l == nil {
+		return noopAdapter{}
+	}
+
 	return printer.Adapter{Printer: printerLogger{l}}
 }
 
@@ -18,3 +23,7 @@ type printerLogger struct {
 func (p printerLogger) Println(skipCallerFrames int, msg string) {
 	_ = p.Logger.Output(skipCallerFrames+2, msg) // nolint
 }
+
+type noopAdapter struct{}
+
+func (n noopAdapter) Log(context.Context, logger.Entry) {}

--- a/adapter/logadapter/logadapter_test.go
+++ b/adapter/logadapter/logadapter_test.go
@@ -1,0 +1,29 @@
+// (c) 2022 Jacek Olszak
+// This code is licensed under MIT license (see LICENSE for details)
+
+package logadapter_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elgopher/yala/adapter/logadapter"
+	"github.com/elgopher/yala/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+const message = "message"
+
+func TestAdapter_Log(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("should not panic when entry is nil", func(t *testing.T) {
+		adapter := logadapter.Adapter(nil)
+		assert.NotPanics(t, func() {
+			adapter.Log(ctx, logger.Entry{
+				Level:   logger.InfoLevel,
+				Message: message,
+			})
+		})
+	})
+}


### PR DESCRIPTION
logadapter.Adapter() func accepts *log.Logger which can be nil. This adapter should support nil logger and don't log anything in such case.