### PR TITLE
[refactor] Simplify Global.SetAdapter

### DIFF
--- a/logger/global.go
+++ b/logger/global.go
@@ -39,13 +39,7 @@ func (g *Global) SetAdapter(adapter Adapter) {
 		adapter = noopAdapter{}
 	}
 
-	if g.rootAdapter != nil {
-		g.rootAdapter.Store(adapterWrapper{Adapter: adapter})
-
-		return
-	}
-
-	g.adapter.Store(adapterWrapper{Adapter: adapter})
+	g.adapterValue().Store(adapterWrapper{Adapter: adapter})
 }
 
 func (g *Global) getAdapter() Adapter { // nolint:ireturn

--- a/logger/logger_bench_test.go
+++ b/logger/logger_bench_test.go
@@ -15,7 +15,7 @@ func BenchmarkInfo(b *testing.B) {
 	var global logger.Global
 
 	for i := 0; i < b.N; i++ {
-		global.Info(ctx, "msg") // 8ns, 0 allocs
+		global.Info(ctx, "msg") // 12ns, 0 allocs
 	}
 }
 


### PR DESCRIPTION
Use adapterValue() method to get adapter atomic.Value instead of if statement. Even though this simplification adds few nanos overhead, it makes code easier to reason about and gets rid of duplicated code.