### PR TITLE
Add Global.WithSkippedCallerFrame

### DIFF
--- a/logger/adapter_mock_test.go
+++ b/logger/adapter_mock_test.go
@@ -43,3 +43,11 @@ func (a *adapterMock) HasExactlyOneEntryWithError(t *testing.T, expected error) 
 	actual := a.entries[0].Error
 	assert.Equal(t, expected, actual)
 }
+
+func (a *adapterMock) HasExactlyOneEntryWithSkippedCallerFrames(t *testing.T, expected int) {
+	t.Helper()
+
+	require.Len(t, a.entries, 1)
+	actual := a.entries[0].SkippedCallerFrames
+	assert.Equal(t, expected, actual)
+}

--- a/logger/global.go
+++ b/logger/global.go
@@ -112,3 +112,15 @@ func (g *Global) WithError(err error) *Global {
 		rootAdapter: g.adapterValue(),
 	}
 }
+
+// WithSkippedCallerFrame creates a new child logger with one more skipped caller frame. This function is handy when you
+// want to write your own logging helpers.
+func (g *Global) WithSkippedCallerFrame() *Global {
+	newEntry := g.entry
+	newEntry.SkippedCallerFrames++
+
+	return &Global{
+		entry:       newEntry,
+		rootAdapter: g.adapterValue(),
+	}
+}


### PR DESCRIPTION
This method is similar to logger.Logger.WithSkippedCallerFrame()

WithSkippedCallerFrame creates a new child logger with one more skipped caller frame. This function is handy when you want to write your own logging helpers.