### PR TITLE
[logrus] Accept also *logrus.Logger in logrus adapter

### DIFF
--- a/adapter/logrusadapter/_example/main.go
+++ b/adapter/logrusadapter/_example/main.go
@@ -15,11 +15,11 @@ var ErrSome = errors.New("some error")
 func main() {
 	ctx := context.Background()
 
-	// First create a logrus logger entry. This is basically a Logger with some optional fields.
-	entry := newLogrusEntry()
-	// Then create a logger.Adapter
+	// First create a logrus logger.
+	l := newLogrusLogger()
+	// Then create a logger.Adapter.
 	adapter := logrusadapter.Adapter{
-		Entry: entry, // inject logrus
+		Logger: l, // you can also pass *logrus.Entry
 	}
 	// Create yala logger
 	log := logger.WithAdapter(adapter)
@@ -30,11 +30,11 @@ func main() {
 	log.WithError(ErrSome).Error(ctx, "Some error")
 }
 
-func newLogrusEntry() *logrus.Entry {
+func newLogrusLogger() *logrus.Logger {
 	l := logrus.New()
 	l.SetLevel(logrus.DebugLevel)
 	l.SetFormatter(&logrus.TextFormatter{
 		ForceColors: true,
 	})
-	return logrus.NewEntry(l)
+	return l
 }

--- a/adapter/logrusadapter/logrus_bench_test.go
+++ b/adapter/logrusadapter/logrus_bench_test.go
@@ -14,9 +14,8 @@ import (
 func BenchmarkLogrus(b *testing.B) {
 	l := logrus.New()
 	l.SetOutput(benchmark.DiscardWriter{})
-	logrusEntry := logrus.NewEntry(l)
 
-	adapter := logrusadapter.Adapter{Entry: logrusEntry}
+	adapter := logrusadapter.Adapter{Logger: l}
 
 	benchmark.Adapter(b, adapter)
 }

--- a/adapter/logrusadapter/logrus_test.go
+++ b/adapter/logrusadapter/logrus_test.go
@@ -23,8 +23,8 @@ const message = "message"
 func TestAdapter_Log(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("should not panic when entry is nil", func(t *testing.T) {
-		adapter := logrusadapter.Adapter{Entry: nil}
+	t.Run("should not panic when logger is nil", func(t *testing.T) {
+		adapter := logrusadapter.Adapter{Logger: nil}
 		assert.NotPanics(t, func() {
 			adapter.Log(ctx, logger.Entry{
 				Level:   logger.InfoLevel,
@@ -45,7 +45,7 @@ func newAdapter(writer io.Writer) logger.Adapter { // nolint
 	logrusLogger.SetOutput(writer)
 	logrusLogger.SetLevel(logrus.DebugLevel)
 
-	return logrusadapter.Adapter{Entry: logrus.NewEntry(logrusLogger)}
+	return logrusadapter.Adapter{Logger: logrusLogger}
 }
 
 var levelMapping = map[string]logger.Level{


### PR DESCRIPTION
So far, only *logrus.Entry was accepted. But sometimes end user would prefer to pass *logrus.Logger directly.

This commit also renames Adapter.Entry field to Adapter.Logger.