### PR TITLE
Add new ***Fields methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ func SetLoggerAdapter(adapter logger.Adapter) {
 func Function(ctx context.Context) {
 	log.Debug(ctx, "Debug message")
 	
-	log.With("field_name", "value").
-		Info(ctx, "Message with field")
+	log.InfoFields(ctx, "Message with field", logger.Fields{
+		"field_name": "value", 
+		"other_name": "value",
+	})
 	
-	log.WithError(errors.New("some")).
-		Error(ctx, "Message with error")
+	log.ErrorCause(ctx, "Message with error", errors.New("some"))
 }
 ```
 
@@ -207,5 +208,5 @@ Unfortunately such interface is much harder to implement, than interface with a 
 
 * even though your package will be independent of any specific logging implementation, you still have to import 
   `github.com/elgopher/yala/logger`. This package is relatively small though, compared to real logging libraries
-  (about ~200 lines of production code) and **it does not import any external libraries**.
+  (about ~250 lines of production code) and **it does not import any external libraries**.
 * yala is not optimized for **extreme** high performance, because this would hurt the developer experience and readability of the created code. Any intermediary API ads overhead - global synchronized variables, wrapper code and even polymorphism slow down the execution a bit. The overhead varies, but it is usually a matter of tens of nanoseconds per call. 

--- a/adapter/console/_example/main.go
+++ b/adapter/console/_example/main.go
@@ -19,12 +19,14 @@ func main() {
 
 	log.Debug(ctx, "Hello fmt")
 
-	log.With("field_name", "field_value").
-		Info(ctx, "Some info")
+	log.InfoFields(ctx, "Some info", logger.Fields{
+		"field_name": "field_value",
+		"other_name": "field_value",
+	})
 
-	log.With("parameter", "some value").
-		Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	log.WarnFields(ctx, "Deprecated configuration parameter. It will be removed.", logger.Fields{
+		"parameter": "some value",
+	})
 
-	log.WithError(ErrSome).
-		Error(ctx, "Some error")
+	log.ErrorCause(ctx, "Some error", ErrSome)
 }

--- a/adapter/glogadapter/_example/main.go
+++ b/adapter/glogadapter/_example/main.go
@@ -21,12 +21,14 @@ func main() {
 
 	log.Debug(ctx, "Hello glog ") // Debug will be logged as Info
 
-	log.With("field_name", "field_value").
-		Info(ctx, "Some info")
+	log.InfoFields(ctx, "Some info", logger.Fields{
+		"field_name": "field_value",
+		"other_name": "field_value",
+	})
 
-	log.With("parameter", "some").
-		Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	log.WarnFields(ctx, "Deprecated configuration parameter. It will be removed.", logger.Fields{
+		"parameter": "some",
+	})
 
-	log.WithError(ErrSome).
-		Error(ctx, "Error occurred")
+	log.ErrorCause(ctx, "Error occurred", ErrSome)
 }

--- a/adapter/internal/benchmark/benchmark.go
+++ b/adapter/internal/benchmark/benchmark.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Adapter runs benchmarks on any implementation of logger.Adapter.
-func Adapter(b *testing.B, adapter logger.Adapter) {
+func Adapter(b *testing.B, adapter logger.Adapter) { // nolint:funlen
 	b.Helper()
 
 	ctx := context.Background()
@@ -26,6 +26,21 @@ func Adapter(b *testing.B, adapter logger.Adapter) {
 
 		for i := 0; i < b.N; i++ {
 			global.Info(ctx, "msg")
+		}
+	})
+
+	b.Run("global logger info with two fields", func(b *testing.B) {
+		var global logger.Global
+		global.SetAdapter(adapter)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			global.InfoFields(ctx, "msg", logger.Fields{
+				"field1": "value",
+				"field2": "value",
+			})
 		}
 	})
 

--- a/adapter/log15adapter/_example/main.go
+++ b/adapter/log15adapter/_example/main.go
@@ -21,12 +21,14 @@ func main() {
 
 	log.Debug(ctx, "Hello log15")
 
-	log.With("field_name", "field_value").
-		Info(ctx, "Some info")
+	log.InfoFields(ctx, "Some info", logger.Fields{
+		"field_name": "field_value",
+		"other_name": "field_value",
+	})
 
-	log.With("parameter", "some").
-		Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	log.WarnFields(ctx, "Deprecated configuration parameter. It will be removed.", logger.Fields{
+		"parameter": "some",
+	})
 
-	log.WithError(ErrSome).
-		Error(ctx, "Some error")
+	log.ErrorCause(ctx, "Some error", ErrSome)
 }

--- a/adapter/logadapter/_example/main.go
+++ b/adapter/logadapter/_example/main.go
@@ -19,17 +19,18 @@ func main() {
 	// log using standard log package
 	standardLog := log.New(os.Stdout, "", log.LstdFlags|log.Lshortfile)
 	adapter := logadapter.Adapter(standardLog)
-	log := logger.WithAdapter(adapter)
+	yalaLogger := logger.WithAdapter(adapter)
 
-	log.Debug(ctx, "Hello standard log")
+	yalaLogger.Debug(ctx, "Hello standard log")
 
-	log.With("f1", "v1").
-		With("f2", "f2").
-		Info(ctx, "Some info")
+	yalaLogger.InfoFields(ctx, "Some info", logger.Fields{
+		"f1": "v1",
+		"f2": "v2",
+	})
 
-	log.With("parameter", "some").
-		Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	yalaLogger.WarnFields(ctx, "Deprecated configuration parameter. It will be removed.", logger.Fields{
+		"parameter": "some",
+	})
 
-	log.WithError(ErrSome).
-		Error(ctx, "Some error")
+	yalaLogger.ErrorCause(ctx, "Some error", ErrSome)
 }

--- a/adapter/logrusadapter/_example/main.go
+++ b/adapter/logrusadapter/_example/main.go
@@ -24,17 +24,18 @@ func main() {
 	// Create yala logger
 	log := logger.WithAdapter(adapter)
 
-	log.Debug(ctx, "Hello logrus ")
+	log.Debug(ctx, "Hello logrus")
 
-	log.With("field_name", "field_value").
-		With("another", "ccc").
-		Info(ctx, "Some info")
+	log.InfoFields(ctx, "Some info", logger.Fields{
+		"field_name": "field_value",
+		"other_name": "field_value",
+	})
 
-	log.With("parameter", "some").
-		Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	log.WarnFields(ctx, "Deprecated configuration parameter. It will be removed.", logger.Fields{
+		"parameter": "some",
+	})
 
-	log.WithError(ErrSome).
-		Error(ctx, "Some error")
+	log.ErrorCause(ctx, "Some error", ErrSome)
 }
 
 func newLogrusLogger() *logrus.Logger {

--- a/adapter/zapadapter/_example/main.go
+++ b/adapter/zapadapter/_example/main.go
@@ -22,14 +22,16 @@ func main() {
 
 	log.Debug(ctx, "Hello zap")
 
-	log.With("field_name", "field_value").
-		Info(ctx, "Some info")
+	log.InfoFields(ctx, "Some info", logger.Fields{
+		"field_name": "field_value",
+		"other_name": "field_value",
+	})
 
-	log.With("parameter", "some").
-		Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	log.WarnFields(ctx, "Deprecated configuration parameter. It will be removed.", logger.Fields{
+		"parameter": "some",
+	})
 
-	log.WithError(ErrSome).
-		Error(ctx, "Some error")
+	log.ErrorCause(ctx, "Some error", ErrSome)
 }
 
 func newZapLogger() *zap.Logger {

--- a/adapter/zerologadapter/_example/main.go
+++ b/adapter/zerologadapter/_example/main.go
@@ -22,12 +22,14 @@ func main() {
 
 	log.Debug(ctx, "Hello zerolog")
 
-	log.With("field_name", "field_value").
-		Info(ctx, "Some info")
+	log.InfoFields(ctx, "Some info", logger.Fields{
+		"field_name": "field_value",
+		"other_name": "field_value",
+	})
 
-	log.With("parameter", "some").
-		Warn(ctx, "Deprecated configuration parameter. It will be removed.")
+	log.WarnFields(ctx, "Deprecated configuration parameter. It will be removed.", logger.Fields{
+		"parameter": "some",
+	})
 
-	log.WithError(ErrSome).
-		Error(ctx, "Some error")
+	log.ErrorCause(ctx, "Some error", ErrSome)
 }

--- a/logger/_examples/caller/main.go
+++ b/logger/_examples/caller/main.go
@@ -43,8 +43,10 @@ func (a ReportCallerAdapter) Log(ctx context.Context, entry logger.Entry) {
 	entry.SkippedCallerFrames++ // each middleware adapter must additionally skip one frame (at least)
 
 	if _, file, line, ok := runtime.Caller(entry.SkippedCallerFrames); ok {
-		entry = entry.With(logger.Field{Key: "file", Value: file})
-		entry = entry.With(logger.Field{Key: "line", Value: line})
+		entry = entry.WithFields(logger.Fields{
+			"file": file,
+			"line": line,
+		})
 	}
 
 	a.NextAdapter.Log(ctx, entry)

--- a/logger/_examples/rename/main.go
+++ b/logger/_examples/rename/main.go
@@ -19,8 +19,9 @@ func main() {
 
 	log := logger.WithAdapter(adapter)
 
-	log.With("this", "value").
-		Info(ctx, "this field will be replaced with that")
+	log.InfoFields(ctx, "this field will be replaced with that", logger.Fields{
+		"this": "value",
+	})
 }
 
 // RenameFieldsAdapter is a middleware (decorator) renaming all fields equal to From into To.

--- a/logger/_examples/reuse/main.go
+++ b/logger/_examples/reuse/main.go
@@ -14,14 +14,18 @@ func main() {
 	log := logger.WithAdapter(console.StdoutAdapter())
 
 	// requestLogger will log all messages with at least two fields: request_id and user
-	requestLogger := log.With("request_id", "123").With("user", "elgopher")
+	requestLogger := log.WithFields(logger.Fields{
+		"request_id": "123",
+		"user":       "elgopher",
+	})
 
 	requestLogger.Debug(ctx, "request started")
 
 	requestLogger.
-		With("rows_updated", 3).
-		With("table", "gophers").
-		Debug(ctx, "sql update executed")
+		DebugFields(ctx, "sql update executed", logger.Fields{
+			"rows_updated": 3,
+			"table":        "gophers",
+		})
 
 	requestLogger.Debug(ctx, "request finished")
 }

--- a/logger/_examples/tags/main.go
+++ b/logger/_examples/tags/main.go
@@ -25,8 +25,7 @@ func main() {
 	// log.Info() -> AddFieldFromContextAdapter -> console adapter
 	log.Info(ctx, "tagged message") // INFO tagged message tag=value
 
-	log.With("k", "v").
-		Info(ctx, "tagged message") // INFO tagged message k=v tag=value
+	log.InfoFields(ctx, "tagged message", logger.Fields{"k": "v"}) // INFO tagged message k=v tag=value
 }
 
 // AddFieldFromContextAdapter is a middleware (decorator) which adds
@@ -36,13 +35,10 @@ type AddFieldFromContextAdapter struct {
 }
 
 func (a AddFieldFromContextAdapter) Log(ctx context.Context, entry logger.Entry) {
-	// entry.With creates an entry and adds a new field to it
-	newEntry := entry.With(
-		logger.Field{
-			Key:   tag,
-			Value: ctx.Value(tag),
-		},
-	)
+	// entry.WithFields creates a copy of the entry with additional fields
+	newEntry := entry.WithFields(logger.Fields{
+		tag: ctx.Value(tag),
+	})
 	newEntry.SkippedCallerFrames++ // each middleware adapter must additionally skip one frame
 	a.NextAdapter.Log(ctx, newEntry)
 }

--- a/logger/adapter.go
+++ b/logger/adapter.go
@@ -44,6 +44,27 @@ func (e Entry) With(field Field) Entry {
 	return e
 }
 
+type Fields map[string]interface{}
+
+// WithFields creates a new entry with additional fields. Fields will be appended, not replaced.
+func (e Entry) WithFields(fields Fields) Entry {
+	if len(fields) == 0 {
+		return e
+	}
+
+	fieldsLength := len(e.Fields)
+	slice := make([]Field, len(e.Fields)+len(fields))
+	copy(slice, e.Fields)
+	e.Fields = slice
+
+	for k, v := range fields {
+		e.Fields[fieldsLength] = Field{k, v}
+		fieldsLength++
+	}
+
+	return e
+}
+
 // Level is a severity level of message. Use Level.MoreSevereThan to compare two levels.
 type Level int8
 

--- a/logger/adapter_test.go
+++ b/logger/adapter_test.go
@@ -1,0 +1,159 @@
+package logger_test
+
+import (
+	"testing"
+
+	"github.com/elgopher/yala/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntry_With(t *testing.T) {
+	field1 := logger.Field{Key: "k1", Value: "v1"}
+	field2 := logger.Field{Key: "k2", Value: "v2"}
+
+	t.Run("should add field to empty entry", func(t *testing.T) {
+		entry := logger.Entry{}
+		newEntry := entry.With(field1)
+		assert.Empty(t, entry.Fields)
+		require.Len(t, newEntry.Fields, 1)
+		assert.Equal(t, newEntry.Fields[0], field1)
+	})
+
+	t.Run("should add field to entry with one field", func(t *testing.T) {
+		entry := logger.Entry{}.With(field1)
+		newEntry := entry.With(field2)
+		require.Len(t, entry.Fields, 1)
+		require.Len(t, newEntry.Fields, 2)
+		assert.Equal(t, entry.Fields[0], field1)
+		assert.Equal(t, newEntry.Fields[0], field1)
+		assert.Equal(t, newEntry.Fields[1], field2)
+	})
+}
+
+func TestEntry_WithFields(t *testing.T) {
+	t.Run("should copy entry when fields is nil", func(t *testing.T) {
+		entry := logger.Entry{}
+		newEntry := entry.WithFields(nil)
+		assert.Equal(t, entry, newEntry)
+	})
+
+	t.Run("should copy entry when fields is empty", func(t *testing.T) {
+		entry := logger.Entry{}
+		newEntry := entry.WithFields(logger.Fields{})
+		assert.Equal(t, entry, newEntry)
+	})
+
+	t.Run("should create new entry with one additional field", func(t *testing.T) {
+		entry := logger.Entry{}
+		// when
+		newEntry := entry.WithFields(logger.Fields{
+			"k": "v",
+		})
+		// then
+		assert.Equal(t,
+			[]logger.Field{{Key: "k", Value: "v"}},
+			newEntry.Fields,
+		)
+		// and leave original entry unchanged
+		assert.Empty(t, entry.Fields)
+	})
+
+	t.Run("should create new entry with two additional fields", func(t *testing.T) {
+		entry := logger.Entry{}
+		// when
+		newEntry := entry.WithFields(logger.Fields{
+			"k1": "v1",
+			"k2": "v2",
+		})
+		// then
+		assert.ElementsMatch(t,
+			[]logger.Field{
+				{Key: "k1", Value: "v1"},
+				{Key: "k2", Value: "v2"},
+			},
+			newEntry.Fields,
+		)
+	})
+
+	t.Run("should create new entry with existing field and one additional field", func(t *testing.T) {
+		existingField := logger.Field{Key: "k1", Value: "v1"}
+		entry := logger.Entry{
+			Fields: []logger.Field{existingField},
+		}
+		// when
+		newEntry := entry.WithFields(logger.Fields{
+			"k2": "v2",
+		})
+		// then
+		assert.Equal(t,
+			[]logger.Field{
+				existingField,
+				{Key: "k2", Value: "v2"},
+			},
+			newEntry.Fields,
+		)
+	})
+
+	t.Run("should create new entry with existing fields and one additional field", func(t *testing.T) {
+		existingFields := []logger.Field{
+			{Key: "k1", Value: "v1"},
+			{Key: "k2", Value: "v2"},
+		}
+		entry := logger.Entry{
+			Fields: existingFields,
+		}
+		// when
+		newEntry := entry.WithFields(logger.Fields{
+			"k3": "v3",
+		})
+		// then
+		assert.Equal(t,
+			[]logger.Field{
+				existingFields[0],
+				existingFields[1],
+				{Key: "k3", Value: "v3"},
+			},
+			newEntry.Fields,
+		)
+	})
+}
+
+func TestLevel_MoreSevereThan(t *testing.T) {
+	t.Run("should return true", func(t *testing.T) {
+		assert.True(t, logger.InfoLevel.MoreSevereThan(logger.DebugLevel))
+		assert.True(t, logger.WarnLevel.MoreSevereThan(logger.DebugLevel))
+		assert.True(t, logger.ErrorLevel.MoreSevereThan(logger.DebugLevel))
+
+		assert.True(t, logger.WarnLevel.MoreSevereThan(logger.InfoLevel))
+		assert.True(t, logger.ErrorLevel.MoreSevereThan(logger.InfoLevel))
+
+		assert.True(t, logger.ErrorLevel.MoreSevereThan(logger.WarnLevel))
+	})
+
+	t.Run("should return false", func(t *testing.T) {
+		assert.False(t, logger.DebugLevel.MoreSevereThan(logger.DebugLevel))
+
+		assert.False(t, logger.DebugLevel.MoreSevereThan(logger.InfoLevel))
+		assert.False(t, logger.InfoLevel.MoreSevereThan(logger.InfoLevel))
+
+		assert.False(t, logger.DebugLevel.MoreSevereThan(logger.WarnLevel))
+		assert.False(t, logger.InfoLevel.MoreSevereThan(logger.WarnLevel))
+		assert.False(t, logger.WarnLevel.MoreSevereThan(logger.WarnLevel))
+
+		assert.False(t, logger.DebugLevel.MoreSevereThan(logger.ErrorLevel))
+		assert.False(t, logger.InfoLevel.MoreSevereThan(logger.ErrorLevel))
+		assert.False(t, logger.WarnLevel.MoreSevereThan(logger.ErrorLevel))
+		assert.False(t, logger.ErrorLevel.MoreSevereThan(logger.ErrorLevel))
+	})
+}
+
+func TestLevel_String(t *testing.T) {
+	t.Run("should convert to string", func(t *testing.T) {
+		assert.Equal(t, "DEBUG", logger.DebugLevel.String())
+		assert.Equal(t, "INFO", logger.InfoLevel.String())
+		assert.Equal(t, "WARN", logger.WarnLevel.String())
+		assert.Equal(t, "ERROR", logger.ErrorLevel.String())
+		assert.Equal(t, "10", logger.Level(10).String())
+	})
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -26,40 +26,78 @@ func WithAdapter(adapter Adapter) Logger {
 
 // Debug logs a message at DebugLevel.
 func (l Logger) Debug(ctx context.Context, msg string) {
-	l.log(ctx, DebugLevel, msg)
+	l.log(ctx, DebugLevel, msg, l.entry.Error, nil)
 }
 
-func (l Logger) log(ctx context.Context, lvl Level, msg string) {
+// DebugFields logs a message at DebugLevel with fields.
+func (l Logger) DebugFields(ctx context.Context, msg string, fields Fields) {
+	l.log(ctx, DebugLevel, msg, l.entry.Error, fields)
+}
+
+func (l Logger) log(ctx context.Context, lvl Level, msg string, cause error, fields Fields) {
 	if l.adapter == nil {
 		return
 	}
 
-	e := l.entry
-	e.Level = lvl
-	e.Message = msg
-	e.SkippedCallerFrames += 2
+	newEntry := l.entry.WithFields(fields)
+	newEntry.Error = cause
+	newEntry.Level = lvl
+	newEntry.Message = msg
+	newEntry.SkippedCallerFrames += 2
 
-	l.adapter.Log(ctx, e)
+	l.adapter.Log(ctx, newEntry)
 }
 
 // Info logs a message at InfoLevel.
 func (l Logger) Info(ctx context.Context, msg string) {
-	l.log(ctx, InfoLevel, msg)
+	l.log(ctx, InfoLevel, msg, l.entry.Error, nil)
+}
+
+// InfoFields logs a message at InfoLevel with fields.
+func (l Logger) InfoFields(ctx context.Context, msg string, fields Fields) {
+	l.log(ctx, InfoLevel, msg, l.entry.Error, fields)
 }
 
 // Warn logs a message at WarnLevel.
 func (l Logger) Warn(ctx context.Context, msg string) {
-	l.log(ctx, WarnLevel, msg)
+	l.log(ctx, WarnLevel, msg, l.entry.Error, nil)
+}
+
+// WarnFields logs a message at WarnLevel with fields.
+func (l Logger) WarnFields(ctx context.Context, msg string, fields Fields) {
+	l.log(ctx, WarnLevel, msg, l.entry.Error, fields)
 }
 
 // Error logs a message at ErrorLevel.
 func (l Logger) Error(ctx context.Context, msg string) {
-	l.log(ctx, ErrorLevel, msg)
+	l.log(ctx, ErrorLevel, msg, l.entry.Error, nil)
 }
 
-// With creates a new logger with field.
+// ErrorCause logs a message at ErrorLevel with cause.
+func (l Logger) ErrorCause(ctx context.Context, msg string, cause error) {
+	l.log(ctx, ErrorLevel, msg, cause, nil)
+}
+
+// ErrorFields logs a message at ErrorLevel with fields.
+func (l Logger) ErrorFields(ctx context.Context, msg string, fields Fields) {
+	l.log(ctx, ErrorLevel, msg, l.entry.Error, fields)
+}
+
+// ErrorCauseFields logs a message at ErrorLevel with cause and fields.
+func (l Logger) ErrorCauseFields(ctx context.Context, msg string, cause error, fields Fields) {
+	l.log(ctx, ErrorLevel, msg, cause, fields)
+}
+
+// With creates a new logger with additional field.
 func (l Logger) With(key string, value interface{}) Logger {
 	l.entry = l.entry.With(Field{key, value})
+
+	return l
+}
+
+// WithFields creates a new logger with additional fields.
+func (l Logger) WithFields(fields Fields) Logger {
+	l.entry = l.entry.WithFields(fields)
 
 	return l
 }

--- a/logger/logger_bench_test.go
+++ b/logger/logger_bench_test.go
@@ -4,6 +4,7 @@
 package logger_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/elgopher/yala/logger"
@@ -57,7 +58,7 @@ func BenchmarkMultipleWith(b *testing.B) {
 	var global logger.Global
 
 	for i := 0; i < b.N; i++ {
-		_ = global.With("k1", "v").With("k2", "v").With("k3", "v") // 235-315ns, 3 allocs
+		global.With("k1", "v").With("k2", "v").With("k3", "v").Info(ctx, "ads") // 530-700ns, 6 allocs
 	}
 }
 
@@ -70,3 +71,24 @@ func BenchmarkWithError(b *testing.B) {
 		_ = global.WithError(ErrSome) // 2.6ns, 0 allocs
 	}
 }
+
+func BenchmarkGlobal_InfoFields(b *testing.B) {
+	var log logger.Global
+
+	log.SetAdapter(discardAdapter{})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		log.InfoFields(ctx, message, logger.Fields{
+			"a": 1,
+			"b": 2,
+			"c": 3,
+		})
+	}
+}
+
+type discardAdapter struct{}
+
+func (d discardAdapter) Log(context.Context, logger.Entry) {}


### PR DESCRIPTION
Right now developer can use fluent-interface API to log message with fields, for example:

```go
log.With("key1","value").
    With("key2","value").
    Info(ctx, "message")
```

For some such design is not intuitive. They prefer to pass fields directly as an Info method parameter. Preferably a map. For example:

```go
log.InfoFields(ctx, "message", logger.Fields{
    "key1": "value",
    "key2": "value",
})
```

Also, the performance of fluent-interface design is not very high. Each With method call creates a new instance of logger with additional field which costs 1 allocation (for normal logger) and 2 allocations (for global one). Most of the time, such logger will be discarded soon (in the very same method), so allocation could be avoided.

The proposed new logger methods can simplify the use of logger and improve the performance.

Here are the changes:

* new logger.Fields type which is a just a map[string]interface{}
* both loggers (logger.Logger and logger.Global) have new methods for directly passing fields:
  * DebugFields(ctx context.Context, msg string, fields Fields)
  * InfoFields(ctx context.Context, msg string, fields Fields)
  * WarnFields(ctx context.Context, msg string, fields Fields)
  * ErrorFields(ctx context.Context, msg string, fields Fields)
* both loggers have new methods for passing an error too:
  * ErrorCause(ctx context.Context, msg string, cause error)
  * ErrorCauseFields(ctx context.Context, msg string, cause error, fields Fields)
* both loggers have new methods for creating a child logger with multiple fields at once:
  * WithFields(Fields)
* logger.Entry has a new method WithFields(Fields)

**All the changes are backwards compatible.**